### PR TITLE
Fix to enable both snabb-softwire-v2 and snabb-softwire-v3 modeled configuration

### DIFF
--- a/src/libyang.c
+++ b/src/libyang.c
@@ -56,11 +56,22 @@ int parse_yang_model(global_ctx_t *ctx) {
     module = (struct lys_module *)ly_ctx_get_module(
         libyang_ctx, "ietf-softwire-common", NULL);
     CHECK_NULL_MSG(module, &rc, cleanup, "ly_ctx_get_module error");
+  /* snabb-softwire-v2 */
+  } else if (0 == strcmp("snabb-softwire-v2", ctx->yang_model)) {
+    module = (struct lys_module *)ly_ctx_get_module(
+        libyang_ctx, ctx->yang_model, "2021-07-13");
+    CHECK_NULL_MSG(module, &rc, cleanup, "ly_ctx_get_module error");
+  /* snabb-softwire-v3 */
+  } else if (0 == strcmp("snabb-softwire-v3", ctx->yang_model)) {
+    module = (struct lys_module *)ly_ctx_get_module(
+        libyang_ctx, ctx->yang_model, "2021-11-08");
+    CHECK_NULL_MSG(module, &rc, cleanup, "ly_ctx_get_module error");
+  } else {
+    rc = SR_ERR_NOT_FOUND;
+    ERR("unsupported model: %s", ctx->yang_model);
+    goto cleanup;
   }
 
-  module = (struct lys_module *)ly_ctx_get_module(libyang_ctx, ctx->yang_model,
-                                                  "2021-11-08");
-  CHECK_NULL_MSG(module, &rc, cleanup, "ly_ctx_get_module error");
 
   ctx->module = module;
 

--- a/src/transform.c
+++ b/src/transform.c
@@ -517,6 +517,10 @@ int sysrepo_datastore_to_snabb(global_ctx_t *ctx) {
   char *message = NULL;
   const char *config_xpath = "/snabb-softwire-v3:softwire-config";
 
+  if(0 == strcmp("snabb-softwire-v2", YANG))
+    config_xpath = "/snabb-softwire-v2:softwire-config";
+
+
   rc = sr_get_subtree(ctx->startup_sess, config_xpath, 0, &startup_data);
   CHECK_RET(rc, cleanup, "failed to get startup data tree: %s",
             sr_strerror(rc));
@@ -671,9 +675,9 @@ int snabb_socket_reconnect(global_ctx_t *ctx) {
   snabb_ps = popen("snabb ps", "r");
   CHECK_NULL_MSG(snabb_ps, &rc, cleanup, "Error opening pipe");
 
-  ret = fgets(line, sizeof(line), snabb_ps);
+  ret = fgets(line, (int)sizeof(line), snabb_ps);
   CHECK_NULL_MSG(ret, &rc, cleanup, "First line of snabb ps is empty");
-  ret = fgets(line, sizeof(line), snabb_ps);
+  ret = fgets(line, (int)sizeof(line), snabb_ps);
   CHECK_NULL_MSG(ret, &rc, cleanup, "Second line of snabb ps is empty");
 
   if (sscanf(line, "  \\- %d   worker for %d", &ignore_pid, &pid) != 2) {
@@ -718,6 +722,9 @@ cleanup:
 bool is_new_snabb_command(iter_change_t *iter, iter_change_t *prev) {
   /* edge case, can't add/remove on XPATH /softwire-config/instance only edit */
   char *cmp_xpath = "/snabb-softwire-v3:softwire-config/instance";
+  if(0 == strcmp("snabb-softwire-v2", YANG))
+    cmp_xpath = "/snabb-softwire-v2:softwire-config/instance";
+
   sr_val_t *tmp_val =
       (SR_OP_DELETED == iter->oper) ? iter->old_val : iter->new_val;
   if (0 == strncmp(cmp_xpath, tmp_val->xpath, strlen(cmp_xpath))) {


### PR DESCRIPTION
Works with the following model+revision:
- snabb-softwire-v2 revision [2021-07-13](https://github.com/eugeneia/snabb/blob/lwaftr-dev-2021-Q3-avf/src/lib/yang/snabb-softwire-v2.yang)
- snabb-softwire-v3 revision [2021-11-08](https://github.com/snabbco/snabb/blob/master/src/lib/yang/snabb-softwire-v3.yang)