### PR TITLE
Fix snabb_data_to_sysrepo data tree copy

### DIFF
--- a/src/transform.c
+++ b/src/transform.c
@@ -489,10 +489,16 @@ int snabb_datastore_to_sysrepo(global_ctx_t *ctx) {
   CHECK_RET(rc, error, "failed parse snabb data in libyang: %s",
             sr_strerror(rc));
 
-  /* copy snabb data to startup datastore */
-  INF_MSG("appply snabb data to sysrepo startup datastore");
-  rc = libyang_data_to_sysrepo(ctx->startup_sess, node);
+  /* copy snabb data to running datastore */
+  INF_MSG("appply snabb data to sysrepo running datastore");
+  rc = libyang_data_to_sysrepo(ctx->sess, node);
   CHECK_RET(rc, error, "failed to apply libyang data to sysrepo: %s",
+            sr_strerror(rc));
+
+  /* copy running -> startup */
+  INF_MSG("copy sysrepo running to startup datastore");
+  rc = sr_copy_config(ctx->startup_sess, YANG, SR_DS_RUNNING, 0);
+  CHECK_RET(rc, error, "failed to copy running to startup datastore: %s",
             sr_strerror(rc));
 
   /* free lyd_node */


### PR DESCRIPTION
When attempting to start sysrepo-snabb-plugin built for [snabb-softwire-v3](https://github.com/eugeneia/snabb.git), an error occurs with the following message:
```
[INF] snabb plugin: sync sysrepo and snabb data
[INF] snabb plugin: copy snabb data to sysrepo
[INF] snabb plugin: send to socket
[INF] snabb plugin: appply snabb data to sysrepo startup datastore
[ERR] snabb plugin: failed lyd_dup_siblings_to_ctx: 5
[ERR] snabb plugin: failed to apply libyang data to sysrepo: Item not found
[ERR] snabb plugin: failed to apply snabb data to sysrepo: Item not found
[ERR] snabb plugin: failed to apply sysrepo startup data to snabb: Item not found
[ERR] sysrepo-plugind: Plugin "sysrepo-snabb-plugin" initialization failed (Item not found).
```

I believe the reason for this is that  function `lyd_dup_siblings_to_ctx` tries to use non-existent schema references from target context (e.g startup) as is noted [tree_data.h]https://github.com/CESNET/libyang/blob/9a4e5b2ce30b9696116d6e654ee55caab5aafed8/src/tree_data.h#L1988-L1991)

This PR fixes this in the following way: 
- data tree created in the context of libyang is first copied to sysrepo running datastore
- running datastore is copied to startup datastore.
